### PR TITLE
Make GID and UID readable from dockerfile env variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,10 @@ ENV RELEASE_VERSION=${RELEASE_VERSION}
 
 # Create User
 ARG UID=1000
+ENV UID=${UID}
 ARG GID=1000
+ENV GID=${GID}
+
 RUN addgroup -g $GID general_user && \
     adduser -D -u $UID -G general_user -s /bin/sh general_user
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ services:
       - spotify_client_secret=123
       - thread_limit=1
       - artist_track_selection=all
+      - UID=1000
+      - GID=1000
     volumes:
       - /path/to/config:/spottube/config
       - /data/media/spottube:/spottube/downloads


### PR DESCRIPTION
Please make it possible that spottube gets the gid and UID from the env Docker variables